### PR TITLE
Updated action.yml to specify use of node16

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cat ~/.clasprc.json
 ## Example usage
 
 ```
-uses: namaggarwal/clasp-token-action@v0.0.1
+uses: namaggarwal/clasp-token-action@v0.0.2
 with:
   client-id: test-client-id
   client-secret: test-client-secret
@@ -62,7 +62,7 @@ package.json
 ```
 {
   "name": "my-project",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "script": {
     "push-to-app": "clasp push"
   }

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Refresh token to get new access token'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'file-plus'


### PR DESCRIPTION
Due to Node.js 12.x being no longer officially supported, GitHub have deprecated use of this version of Node for Actions.

More detail on this change here: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Trying to use the 0.0.1 version of the action results in a warning that node12 is no longer supported.

This PR bumps the Node version in use to `node16` in `action.yml` in line with the recommendation from the article above.

It also assumes another tag push to **0.0.2** so there are changes to the `README.md` that reflect this change.